### PR TITLE
Implement client login and password recovery

### DIFF
--- a/back-end/cliente-service/src/main/java/com/example/cliente_service/ClienteServiceApplication.java
+++ b/back-end/cliente-service/src/main/java/com/example/cliente_service/ClienteServiceApplication.java
@@ -2,11 +2,17 @@ package com.example.cliente_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-
-// importa esta clase:
 import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @SpringBootApplication(exclude = { UserDetailsServiceAutoConfiguration.class })
 public class ClienteServiceApplication {
   public static void main(String[] args) { SpringApplication.run(ClienteServiceApplication.class, args); }
+
+  @Bean
+  PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
 }

--- a/back-end/cliente-service/src/main/java/com/example/cliente_service/clientes/Cliente.java
+++ b/back-end/cliente-service/src/main/java/com/example/cliente_service/clientes/Cliente.java
@@ -33,6 +33,11 @@ public class Cliente {
   @Column(unique = true, nullable = false, length = 160)
   private String email;
 
+  @NotBlank
+  @Size(max = 80)
+  @Column(nullable = false, length = 80)
+  private String clave;
+
   @Size(max = 40)
   @Column(length = 40)
   private String telefono;

--- a/back-end/cliente-service/src/main/java/com/example/cliente_service/clientes/ClienteController.java
+++ b/back-end/cliente-service/src/main/java/com/example/cliente_service/clientes/ClienteController.java
@@ -4,6 +4,8 @@ import com.example.cliente_service.clientes.dto.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.server.ResponseStatusException;
 
 import jakarta.validation.Valid;
 import java.util.List;
@@ -14,6 +16,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class ClienteController {
   private final ClienteRepository repo;
+  private final PasswordEncoder encoder;
 
   @GetMapping
   public List<ClienteRes> listar() {
@@ -22,7 +25,10 @@ public class ClienteController {
 
   @GetMapping("/{id}")
   public ClienteRes ver(@PathVariable UUID id) {
-    return repo.findById(id).map(ClienteRes::of).orElseThrow();
+    return repo
+        .findById(id)
+        .map(ClienteRes::of)
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
   }
 
   @PostMapping
@@ -32,22 +38,46 @@ public class ClienteController {
         .nombre(req.nombre())
         .email(req.email())
         .telefono(req.telefono())
+        .clave(encoder.encode(req.clave()))
         .build();
     return ClienteRes.of(repo.save(c));
   }
 
   @PutMapping("/{id}")
   public ClienteRes actualizar(@PathVariable UUID id, @Valid @RequestBody ClienteReq req) {
-    var c = repo.findById(id).orElseThrow();
+    var c =
+        repo
+            .findById(id)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     c.setNombre(req.nombre());
     c.setEmail(req.email());
     c.setTelefono(req.telefono());
+    c.setClave(encoder.encode(req.clave()));
     return ClienteRes.of(repo.save(c));
   }
 
   @DeleteMapping("/{id}")
   @ResponseStatus(HttpStatus.NO_CONTENT)
   public void eliminar(@PathVariable UUID id) {
+    if (!repo.existsById(id)) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+    }
     repo.deleteById(id);
+  }
+
+  @PostMapping("/login")
+  public ClienteRes login(@Valid @RequestBody LoginReq req) {
+    var c = repo.findByEmail(req.email()).orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED));
+    if (!encoder.matches(req.clave(), c.getClave())) {
+      throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
+    }
+    return ClienteRes.of(c);
+  }
+
+  @PostMapping("/recuperar-clave")
+  public ClienteRes recuperarClave(@Valid @RequestBody RecuperarClaveReq req) {
+    var c = repo.findByEmail(req.email()).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+    c.setClave(encoder.encode(req.nuevaClave()));
+    return ClienteRes.of(repo.save(c));
   }
 }

--- a/back-end/cliente-service/src/main/java/com/example/cliente_service/clientes/ClienteRepository.java
+++ b/back-end/cliente-service/src/main/java/com/example/cliente_service/clientes/ClienteRepository.java
@@ -1,4 +1,9 @@
 package com.example.cliente_service.clientes;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
 import java.util.UUID;
-public interface ClienteRepository extends JpaRepository<Cliente, UUID> {}
+
+public interface ClienteRepository extends JpaRepository<Cliente, UUID> {
+  Optional<Cliente> findByEmail(String email);
+}

--- a/back-end/cliente-service/src/main/java/com/example/cliente_service/clientes/dto/ClienteReq.java
+++ b/back-end/cliente-service/src/main/java/com/example/cliente_service/clientes/dto/ClienteReq.java
@@ -3,5 +3,6 @@ import jakarta.validation.constraints.*;
 public record ClienteReq(
   @NotBlank @Size(max=120) String nombre,
   @NotBlank @Email @Size(max=160) String email,
-  @Size(max=40) String telefono
+  @Size(max=40) String telefono,
+  @NotBlank @Size(max=80) String clave
 ) {}

--- a/back-end/cliente-service/src/main/java/com/example/cliente_service/clientes/dto/ClienteRes.java
+++ b/back-end/cliente-service/src/main/java/com/example/cliente_service/clientes/dto/ClienteRes.java
@@ -1,8 +1,9 @@
 package com.example.cliente_service.clientes.dto;
 import com.example.cliente_service.clientes.Cliente;
 import java.util.UUID;
-public record ClienteRes(UUID id, String nombre, String email, String telefono) {
+
+public record ClienteRes(UUID id, String nombre, String email, String telefono, String clave) {
   public static ClienteRes of(Cliente c) {
-    return new ClienteRes(c.getId(), c.getNombre(), c.getEmail(), c.getTelefono());
+    return new ClienteRes(c.getId(), c.getNombre(), c.getEmail(), c.getTelefono(), c.getClave());
   }
 }

--- a/back-end/cliente-service/src/main/java/com/example/cliente_service/clientes/dto/LoginReq.java
+++ b/back-end/cliente-service/src/main/java/com/example/cliente_service/clientes/dto/LoginReq.java
@@ -1,0 +1,11 @@
+package com.example.cliente_service.clientes.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record LoginReq(
+    @NotBlank @Email @Size(max = 160) String email,
+    @NotBlank @Size(max = 80) String clave
+) {}
+

--- a/back-end/cliente-service/src/main/java/com/example/cliente_service/clientes/dto/RecuperarClaveReq.java
+++ b/back-end/cliente-service/src/main/java/com/example/cliente_service/clientes/dto/RecuperarClaveReq.java
@@ -1,0 +1,11 @@
+package com.example.cliente_service.clientes.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record RecuperarClaveReq(
+    @NotBlank @Email @Size(max = 160) String email,
+    @NotBlank @Size(max = 80) String nuevaClave
+) {}
+


### PR DESCRIPTION
## Summary
- include password in client responses
- add login and password recovery endpoints for clients
- return 404 when client is missing in lookup, update or delete

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a8068e87c883248d79674d8e6c0284