### PR TITLE
Validate unique client emails before save

### DIFF
--- a/back-end/cliente-service/pom.xml
+++ b/back-end/cliente-service/pom.xml
@@ -74,12 +74,17 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.security</groupId>
-			<artifactId>spring-security-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+                <dependency>
+                        <groupId>org.springframework.security</groupId>
+                        <artifactId>spring-security-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>com.h2database</groupId>
+                        <artifactId>h2</artifactId>
+                        <scope>test</scope>
+                </dependency>
+        </dependencies>
 
 	<build>
 		<plugins>

--- a/back-end/cliente-service/src/main/java/com/example/cliente_service/clientes/ClienteController.java
+++ b/back-end/cliente-service/src/main/java/com/example/cliente_service/clientes/ClienteController.java
@@ -34,12 +34,20 @@ public class ClienteController {
   @PostMapping
   @ResponseStatus(HttpStatus.CREATED)
   public ClienteRes crear(@Valid @RequestBody ClienteReq req) {
-    var c = Cliente.builder()
-        .nombre(req.nombre())
-        .email(req.email())
-        .telefono(req.telefono())
-        .clave(encoder.encode(req.clave()))
-        .build();
+    repo
+        .findByEmail(req.email())
+        .ifPresent(
+            c -> {
+              throw new ResponseStatusException(
+                  HttpStatus.CONFLICT, "El email ya está en uso");
+            });
+    var c =
+        Cliente.builder()
+            .nombre(req.nombre())
+            .email(req.email())
+            .telefono(req.telefono())
+            .clave(encoder.encode(req.clave()))
+            .build();
     return ClienteRes.of(repo.save(c));
   }
 
@@ -49,6 +57,14 @@ public class ClienteController {
         repo
             .findById(id)
             .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+    repo
+        .findByEmail(req.email())
+        .filter(existing -> !existing.getId().equals(id))
+        .ifPresent(
+            existing -> {
+              throw new ResponseStatusException(
+                  HttpStatus.CONFLICT, "El email ya está en uso");
+            });
     c.setNombre(req.nombre());
     c.setEmail(req.email());
     c.setTelefono(req.telefono());

--- a/back-end/cliente-service/src/test/java/com/example/cliente_service/clientes/ClienteControllerIntegrationTest.java
+++ b/back-end/cliente-service/src/test/java/com/example/cliente_service/clientes/ClienteControllerIntegrationTest.java
@@ -1,0 +1,56 @@
+package com.example.cliente_service.clientes;
+
+import com.example.cliente_service.clientes.dto.ClienteReq;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class ClienteControllerIntegrationTest {
+
+  @Autowired MockMvc mvc;
+  @Autowired ObjectMapper mapper;
+  @Autowired ClienteRepository repo;
+
+  @BeforeEach
+  void setUp() {
+    repo.deleteAll();
+  }
+
+  @Test
+  void crearConEmailDuplicadoRetornaConflict() throws Exception {
+    repo.save(Cliente.builder().nombre("A").email("a@a.com").telefono("123").clave("x").build());
+    var req = new ClienteReq("B", "a@a.com", "321", "y");
+    mvc
+        .perform(
+            post("/api/clientes")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(req)))
+        .andExpect(status().isConflict());
+  }
+
+  @Test
+  void actualizarConEmailDeOtroRetornaConflict() throws Exception {
+    repo.save(Cliente.builder().nombre("A").email("a@a.com").telefono("111").clave("x").build());
+    var otro =
+        repo.save(Cliente.builder().nombre("B").email("b@b.com").telefono("222").clave("y").build());
+    var req = new ClienteReq("B2", "a@a.com", "222", "y");
+    mvc
+        .perform(
+            put("/api/clientes/" + otro.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(req)))
+        .andExpect(status().isConflict());
+  }
+}
+


### PR DESCRIPTION
## Summary
- check ClienteRepository for existing email before creating or updating a client
- add integration tests for duplicate email scenarios
- include H2 database for tests

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.example:cliente-service:0.0.1-SNAPSHOT: The following artifacts could not be resolved: org.springframework.boot:spring-boot-starter-parent:pom:3.4.8 (absent): Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.8 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68aa9b02b9508324b25701afbb44a583