### PR TITLE
Add recovery token validation before password reset

### DIFF
--- a/back-end/cliente-service/README.md
+++ b/back-end/cliente-service/README.md
@@ -1,0 +1,21 @@
+# Cliente Service
+
+## Password Recovery
+
+Each client has a recovery token stored in the `tokenRecuperacion` field. The token is automatically generated when a client account is created and returned in the service responses. Clients should store this token securely.
+
+### Resetting the Password
+
+1. Send a request to `POST /api/clientes/recuperar-clave` with the following body:
+   ```json
+   {
+     "email": "usuario@example.com",
+     "token": "<tokenRecuperacion>",
+     "nuevaClave": "nuevaPassword"
+   }
+   ```
+2. The service validates the token before updating the password.
+3. A new recovery token is generated and included in the response.
+
+If the token does not match, the service returns `401 Unauthorized`.
+

--- a/back-end/cliente-service/src/main/java/com/example/cliente_service/clientes/Cliente.java
+++ b/back-end/cliente-service/src/main/java/com/example/cliente_service/clientes/Cliente.java
@@ -42,6 +42,10 @@ public class Cliente {
   @Column(length = 40)
   private String telefono;
 
+  @Size(max = 120)
+  @Column(name = "token_recuperacion", length = 120)
+  private String tokenRecuperacion;
+
   @Column(name = "creado_en", nullable = false, columnDefinition = "timestamptz")
   @Builder.Default
   private OffsetDateTime creadoEn = OffsetDateTime.now();

--- a/back-end/cliente-service/src/main/java/com/example/cliente_service/clientes/ClienteController.java
+++ b/back-end/cliente-service/src/main/java/com/example/cliente_service/clientes/ClienteController.java
@@ -39,6 +39,7 @@ public class ClienteController {
         .email(req.email())
         .telefono(req.telefono())
         .clave(encoder.encode(req.clave()))
+        .tokenRecuperacion(UUID.randomUUID().toString())
         .build();
     return ClienteRes.of(repo.save(c));
   }
@@ -77,7 +78,11 @@ public class ClienteController {
   @PostMapping("/recuperar-clave")
   public ClienteRes recuperarClave(@Valid @RequestBody RecuperarClaveReq req) {
     var c = repo.findByEmail(req.email()).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+    if (!req.token().equals(c.getTokenRecuperacion())) {
+      throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
+    }
     c.setClave(encoder.encode(req.nuevaClave()));
+    c.setTokenRecuperacion(UUID.randomUUID().toString());
     return ClienteRes.of(repo.save(c));
   }
 }

--- a/back-end/cliente-service/src/main/java/com/example/cliente_service/clientes/dto/ClienteRes.java
+++ b/back-end/cliente-service/src/main/java/com/example/cliente_service/clientes/dto/ClienteRes.java
@@ -2,8 +2,20 @@ package com.example.cliente_service.clientes.dto;
 import com.example.cliente_service.clientes.Cliente;
 import java.util.UUID;
 
-public record ClienteRes(UUID id, String nombre, String email, String telefono, String clave) {
+public record ClienteRes(
+    UUID id,
+    String nombre,
+    String email,
+    String telefono,
+    String clave,
+    String tokenRecuperacion) {
   public static ClienteRes of(Cliente c) {
-    return new ClienteRes(c.getId(), c.getNombre(), c.getEmail(), c.getTelefono(), c.getClave());
+    return new ClienteRes(
+        c.getId(),
+        c.getNombre(),
+        c.getEmail(),
+        c.getTelefono(),
+        c.getClave(),
+        c.getTokenRecuperacion());
   }
 }

--- a/back-end/cliente-service/src/main/java/com/example/cliente_service/clientes/dto/RecuperarClaveReq.java
+++ b/back-end/cliente-service/src/main/java/com/example/cliente_service/clientes/dto/RecuperarClaveReq.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.Size;
 
 public record RecuperarClaveReq(
     @NotBlank @Email @Size(max = 160) String email,
+    @NotBlank @Size(max = 120) String token,
     @NotBlank @Size(max = 80) String nuevaClave
 ) {}
 


### PR DESCRIPTION
## Summary
- store a recovery token on `Cliente`
- validate the token before allowing password reset
- document the password recovery flow and token usage

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68aa9b0126d0832490d6fd20a5cf54fe