### PR TITLE
Add registration and login endpoints to auth service

### DIFF
--- a/back-end/auth-service/src/main/java/com/example/auth_service/config/SecurityConfig.java
+++ b/back-end/auth-service/src/main/java/com/example/auth_service/config/SecurityConfig.java
@@ -9,14 +9,15 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
@@ -32,6 +33,7 @@ import org.springframework.security.oauth2.server.authorization.settings.TokenSe
 import org.springframework.security.oauth2.server.authorization.token.JwtEncodingContext;
 import org.springframework.security.oauth2.server.authorization.token.OAuth2TokenCustomizer;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.provisioning.UserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -65,7 +67,7 @@ public class SecurityConfig {
       .csrf(AbstractHttpConfigurer::disable)
       .cors(Customizer.withDefaults())
       .authorizeHttpRequests(auth -> auth
-        .requestMatchers("/actuator/**").permitAll()
+        .requestMatchers("/actuator/**", "/auth/register", "/auth/login").permitAll()
         .anyRequest().authenticated())
       .formLogin(Customizer.withDefaults());
     return http.build();
@@ -132,7 +134,7 @@ public class SecurityConfig {
 
   // --- Usuarios con Roles (demo) ---
   @Bean
-  UserDetailsService users(PasswordEncoder encoder) {
+  UserDetailsManager users(PasswordEncoder encoder) {
     UserDetails admin = User.withUsername("admin")
       .password(encoder.encode("admin123"))
       .roles("ADMIN")
@@ -150,6 +152,12 @@ public class SecurityConfig {
   @Bean
   PasswordEncoder passwordEncoder() {
     return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+  }
+
+  // --- Authentication manager ---
+  @Bean
+  AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+    return configuration.getAuthenticationManager();
   }
 
   // --- Customizer: incluir claim "roles" en access token e id token ---

--- a/back-end/auth-service/src/main/java/com/example/auth_service/controller/AuthController.java
+++ b/back-end/auth-service/src/main/java/com/example/auth_service/controller/AuthController.java
@@ -1,0 +1,53 @@
+package com.example.auth_service.controller;
+
+import com.example.auth_service.dto.LoginRequest;
+import com.example.auth_service.dto.RegisterRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.provisioning.UserDetailsManager;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+public class AuthController {
+
+  private final PasswordEncoder passwordEncoder;
+  private final UserDetailsManager userDetailsManager;
+  private final AuthenticationManager authenticationManager;
+
+  public AuthController(PasswordEncoder passwordEncoder,
+                        UserDetailsManager userDetailsManager,
+                        AuthenticationManager authenticationManager) {
+    this.passwordEncoder = passwordEncoder;
+    this.userDetailsManager = userDetailsManager;
+    this.authenticationManager = authenticationManager;
+  }
+
+  @PostMapping("/register")
+  public ResponseEntity<String> register(@RequestBody RegisterRequest request) {
+    if (userDetailsManager.userExists(request.username())) {
+      return ResponseEntity.badRequest().body("User already exists");
+    }
+    UserDetails user = User.withUsername(request.username())
+        .password(passwordEncoder.encode(request.password()))
+        .roles(request.role().toUpperCase())
+        .build();
+    userDetailsManager.createUser(user);
+    return ResponseEntity.ok("User registered");
+  }
+
+  @PostMapping("/login")
+  public ResponseEntity<String> login(@RequestBody LoginRequest request) {
+    UsernamePasswordAuthenticationToken token =
+        new UsernamePasswordAuthenticationToken(request.username(), request.password());
+    authenticationManager.authenticate(token);
+    return ResponseEntity.ok("Login successful");
+  }
+}

--- a/back-end/auth-service/src/main/java/com/example/auth_service/dto/LoginRequest.java
+++ b/back-end/auth-service/src/main/java/com/example/auth_service/dto/LoginRequest.java
@@ -1,0 +1,3 @@
+package com.example.auth_service.dto;
+
+public record LoginRequest(String username, String password) {}

--- a/back-end/auth-service/src/main/java/com/example/auth_service/dto/RegisterRequest.java
+++ b/back-end/auth-service/src/main/java/com/example/auth_service/dto/RegisterRequest.java
@@ -1,0 +1,3 @@
+package com.example.auth_service.dto;
+
+public record RegisterRequest(String username, String password, String role) {}


### PR DESCRIPTION
## Summary
- add `/auth/register` and `/auth/login` endpoints
- allow unauthenticated access to new auth endpoints
- expose `AuthenticationManager` bean for manual authentication

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a59798cf5883248ff2fe2af0b4b435