### PR TITLE
feat: add basic angular frontend

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json.schemastore.org/angular-cli",
+  "version": 1,
+  "newProjectRoot": "projects",
+  "projects": {
+    "pedido-frontend": {
+      "projectType": "application",
+      "root": "",
+      "sourceRoot": "src",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:browser",
+          "options": {
+            "outputPath": "dist/pedido-frontend",
+            "index": "src/index.html",
+            "main": "src/main.ts",
+            "polyfills": ["zone.js"],
+            "tsConfig": "tsconfig.app.json",
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.css"],
+            "scripts": []
+          }
+        },
+        "serve": {
+          "builder": "@angular-devkit/build-angular:dev-server",
+          "options": {
+            "browserTarget": "pedido-frontend:build"
+          }
+        },
+        "test": {
+          "builder": "@angular-devkit/build-angular:karma",
+          "options": {
+            "main": "src/test.ts",
+            "polyfills": ["zone.js", "zone.js/testing"],
+            "tsConfig": "tsconfig.spec.json",
+            "karmaConfig": "karma.conf.js"
+          }
+        }
+      }
+    }
+  }
+}

--- a/frontend/karma.conf.js
+++ b/frontend/karma.conf.js
@@ -1,0 +1,24 @@
+module.exports = function (config) {
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage'),
+      require('@angular-devkit/build-angular/plugins/karma')
+    ],
+    client: {
+      clearContext: false
+    },
+    coverageReporter: {
+      dir: require('path').join(__dirname, './coverage'),
+      subdir: '.',
+      reporters: [{ type: 'html' }, { type: 'text-summary' }]
+    },
+    reporters: ['progress', 'kjhtml'],
+    browsers: ['ChromeHeadless'],
+    restartOnFileChange: true
+  });
+};

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "pedido-frontend",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "start": "ng serve",
+    "build": "ng build",
+    "test": "ng test"
+  },
+  "dependencies": {
+    "@angular/animations": "^17.3.0",
+    "@angular/common": "^17.3.0",
+    "@angular/compiler": "^17.3.0",
+    "@angular/core": "^17.3.0",
+    "@angular/forms": "^17.3.0",
+    "@angular/platform-browser": "^17.3.0",
+    "@angular/platform-browser-dynamic": "^17.3.0",
+    "@angular/router": "^17.3.0",
+    "rxjs": "~7.8.0",
+    "tslib": "^2.5.0",
+    "zone.js": "~0.13.0",
+    "@angular-oauth2-oidc": "^17.0.2"
+  },
+  "devDependencies": {
+    "@angular-devkit/build-angular": "^17.3.0",
+    "@angular/cli": "^17.3.0",
+    "@angular/compiler-cli": "^17.3.0",
+    "typescript": "~5.3.2"
+  }
+}

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -1,0 +1,37 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { LoginComponent } from './pages/login.component';
+import { PedidoFormComponent } from './components/pedido-form.component';
+import { PedidoListComponent } from './components/pedido-list.component';
+import { TrackingComponent } from './components/tracking.component';
+import { AuthGuard } from './guards/auth.guard';
+import { RoleGuard } from './guards/role.guard';
+
+const routes: Routes = [
+  { path: 'login', component: LoginComponent },
+  {
+    path: 'nuevo',
+    component: PedidoFormComponent,
+    canActivate: [AuthGuard, RoleGuard],
+    data: { role: 'CLIENTE' }
+  },
+  {
+    path: 'mis-pedidos',
+    component: PedidoListComponent,
+    canActivate: [AuthGuard, RoleGuard],
+    data: { role: 'CLIENTE' }
+  },
+  {
+    path: 'tracking',
+    component: TrackingComponent,
+    canActivate: [AuthGuard, RoleGuard],
+    data: { role: 'CLIENTE' }
+  },
+  { path: '', redirectTo: 'mis-pedidos', pathMatch: 'full' }
+];
+
+@NgModule({
+  imports: [RouterModule.forRoot(routes)],
+  exports: [RouterModule]
+})
+export class AppRoutingModule {}

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -1,0 +1,8 @@
+<nav>
+  <a routerLink="/mis-pedidos" *ngIf="auth.isLoggedIn()">Pedidos</a>
+  <a routerLink="/nuevo" *ngIf="auth.isLoggedIn()">Nuevo Pedido</a>
+  <a routerLink="/tracking" *ngIf="auth.isLoggedIn()">Tracking</a>
+  <a routerLink="/login" *ngIf="!auth.isLoggedIn()">Login</a>
+  <a href="#" (click)="logout()" *ngIf="auth.isLoggedIn()">Logout</a>
+</nav>
+<router-outlet></router-outlet>

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,0 +1,14 @@
+import { Component } from '@angular/core';
+import { AuthService } from './services/auth.service';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: './app.component.html'
+})
+export class AppComponent {
+  constructor(public auth: AuthService) {}
+
+  logout() {
+    this.auth.logout();
+  }
+}

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -1,0 +1,36 @@
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+
+import { AppComponent } from './app.component';
+import { AppRoutingModule } from './app-routing.module';
+import { LoginComponent } from './pages/login.component';
+import { PedidoFormComponent } from './components/pedido-form.component';
+import { PedidoListComponent } from './components/pedido-list.component';
+import { TrackingComponent } from './components/tracking.component';
+import { AuthInterceptor } from './interceptors/auth.interceptor';
+
+@NgModule({
+  declarations: [
+    AppComponent,
+    LoginComponent,
+    PedidoFormComponent,
+    PedidoListComponent,
+    TrackingComponent
+  ],
+  imports: [
+    BrowserModule,
+    HttpClientModule,
+    FormsModule,
+    ReactiveFormsModule,
+    RouterModule,
+    AppRoutingModule
+  ],
+  providers: [
+    { provide: HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true }
+  ],
+  bootstrap: [AppComponent]
+})
+export class AppModule {}

--- a/frontend/src/app/components/pedido-form.component.ts
+++ b/frontend/src/app/components/pedido-form.component.ts
@@ -1,0 +1,31 @@
+import { Component } from '@angular/core';
+import { PedidoService } from '../services/pedido.service';
+
+@Component({
+  selector: 'app-pedido-form',
+  template: `
+    <h2>Nuevo Pedido</h2>
+    <form (ngSubmit)="crear()">
+      <label>Cliente ID</label>
+      <input [(ngModel)]="clienteId" name="clienteId" required />
+      <label>Total</label>
+      <input type="number" [(ngModel)]="total" name="total" required />
+      <button type="submit">Crear</button>
+    </form>
+    <div *ngIf="mensaje">{{ mensaje }}</div>
+  `
+})
+export class PedidoFormComponent {
+  clienteId = '';
+  total = 0;
+  mensaje = '';
+
+  constructor(private pedidos: PedidoService) {}
+
+  crear() {
+    this.pedidos.crear({ clienteId: this.clienteId, total: this.total }).subscribe(
+      p => (this.mensaje = `Pedido ${p.id} creado`),
+      () => (this.mensaje = 'Error al crear')
+    );
+  }
+}

--- a/frontend/src/app/components/pedido-list.component.ts
+++ b/frontend/src/app/components/pedido-list.component.ts
@@ -1,0 +1,25 @@
+import { Component } from '@angular/core';
+import { Pedido, PedidoService } from '../services/pedido.service';
+
+@Component({
+  selector: 'app-pedido-list',
+  template: `
+    <h2>Mis pedidos</h2>
+    <label>Cliente ID</label>
+    <input [(ngModel)]="clienteId" />
+    <button (click)="buscar()">Buscar</button>
+    <ul>
+      <li *ngFor="let p of pedidos">{{ p.id }} - {{ p.estado }} - {{ p.total }}</li>
+    </ul>
+  `
+})
+export class PedidoListComponent {
+  clienteId = '';
+  pedidos: Pedido[] = [];
+
+  constructor(private service: PedidoService) {}
+
+  buscar() {
+    this.service.listarPorCliente(this.clienteId).subscribe(res => (this.pedidos = res));
+  }
+}

--- a/frontend/src/app/components/tracking.component.ts
+++ b/frontend/src/app/components/tracking.component.ts
@@ -1,0 +1,57 @@
+import { Component } from '@angular/core';
+import { PedidoService, Pedido } from '../services/pedido.service';
+import { TrackingService, TrackingEntry } from '../services/tracking.service';
+
+@Component({
+  selector: 'app-tracking',
+  template: `
+    <h2>Tracking</h2>
+    <label>ID Pedido</label>
+    <input [(ngModel)]="pedidoId" />
+    <button (click)="consultar()">Consultar</button>
+    <div *ngIf="pedido">
+      <h3>MySQL</h3>
+      <pre>{{ pedido | json }}</pre>
+    </div>
+    <div *ngIf="tracking">
+      <h3>Redis</h3>
+      <pre>{{ tracking | json }}</pre>
+    </div>
+    <div *ngIf="pedido && tracking && discrepancia" class="alert">Datos desactualizados</div>
+  `
+})
+export class TrackingComponent {
+  pedidoId = '';
+  pedido: Pedido | null = null;
+  tracking: TrackingEntry | null = null;
+  discrepancia = false;
+
+  constructor(
+    private pedidos: PedidoService,
+    private trackingService: TrackingService
+  ) {}
+
+  consultar() {
+    this.pedido = null;
+    this.tracking = null;
+    this.discrepancia = false;
+
+    this.pedidos.ver(this.pedidoId).subscribe(p => {
+      this.pedido = p;
+      this.compare();
+    });
+
+    this.trackingService.obtener(this.pedidoId).subscribe(t => {
+      this.tracking = t;
+      this.compare();
+    });
+  }
+
+  private compare() {
+    if (this.pedido && this.tracking) {
+      this.discrepancia =
+        this.pedido.estado !== this.tracking.estado ||
+        this.pedido.total !== this.tracking.total;
+    }
+  }
+}

--- a/frontend/src/app/guards/auth.guard.ts
+++ b/frontend/src/app/guards/auth.guard.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, Router, UrlTree } from '@angular/router';
+import { AuthService } from '../services/auth.service';
+
+@Injectable({ providedIn: 'root' })
+export class AuthGuard implements CanActivate {
+  constructor(private auth: AuthService, private router: Router) {}
+
+  canActivate(): boolean | UrlTree {
+    if (this.auth.isLoggedIn()) {
+      return true;
+    }
+    return this.router.parseUrl('/login');
+  }
+}

--- a/frontend/src/app/guards/role.guard.ts
+++ b/frontend/src/app/guards/role.guard.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, ActivatedRouteSnapshot, Router, UrlTree } from '@angular/router';
+import { AuthService } from '../services/auth.service';
+
+@Injectable({ providedIn: 'root' })
+export class RoleGuard implements CanActivate {
+  constructor(private auth: AuthService, private router: Router) {}
+
+  canActivate(route: ActivatedRouteSnapshot): boolean | UrlTree {
+    const role = route.data['role'];
+    if (this.auth.isLoggedIn() && this.auth.hasRole(role)) {
+      return true;
+    }
+    return this.router.parseUrl('/login');
+  }
+}

--- a/frontend/src/app/interceptors/auth.interceptor.ts
+++ b/frontend/src/app/interceptors/auth.interceptor.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@angular/core';
+import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { AuthService } from '../services/auth.service';
+
+@Injectable()
+export class AuthInterceptor implements HttpInterceptor {
+  constructor(private auth: AuthService) {}
+
+  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    const token = this.auth.getToken();
+    if (token) {
+      req = req.clone({ setHeaders: { Authorization: `Bearer ${token}` } });
+    }
+    return next.handle(req);
+  }
+}

--- a/frontend/src/app/pages/login.component.ts
+++ b/frontend/src/app/pages/login.component.ts
@@ -1,0 +1,32 @@
+import { Component } from '@angular/core';
+import { Router } from '@angular/router';
+import { AuthService } from '../services/auth.service';
+
+@Component({
+  selector: 'app-login',
+  template: `
+    <h2>Login</h2>
+    <form (ngSubmit)="submit()">
+      <label>Email</label>
+      <input [(ngModel)]="username" name="username" required />
+      <label>Password</label>
+      <input [(ngModel)]="password" name="password" type="password" required />
+      <button type="submit">Ingresar</button>
+    </form>
+    <div *ngIf="error" class="alert">{{ error }}</div>
+  `
+})
+export class LoginComponent {
+  username = '';
+  password = '';
+  error: string | null = null;
+
+  constructor(private auth: AuthService, private router: Router) {}
+
+  submit() {
+    this.auth.login(this.username, this.password).subscribe({
+      next: () => this.router.navigate(['/mis-pedidos']),
+      error: () => (this.error = 'Credenciales inválidas')
+    });
+  }
+}

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -1,0 +1,56 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Router } from '@angular/router';
+import { tap } from 'rxjs/operators';
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private tokenKey = 'auth_token';
+  private api = 'http://localhost:8080'; // gateway
+
+  constructor(private http: HttpClient, private router: Router) {}
+
+  login(username: string, password: string) {
+    const body = new URLSearchParams();
+    body.set('grant_type', 'password');
+    body.set('username', username);
+    body.set('password', password);
+
+    const headers = new HttpHeaders({
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Authorization: 'Basic ' + btoa('front-client:')
+    });
+
+    return this.http
+      .post<any>(`${this.api}/oauth2/token`, body.toString(), { headers })
+      .pipe(tap(res => localStorage.setItem(this.tokenKey, res.access_token)));
+  }
+
+  logout() {
+    localStorage.removeItem(this.tokenKey);
+    this.router.navigate(['/login']);
+  }
+
+  getToken(): string | null {
+    return localStorage.getItem(this.tokenKey);
+  }
+
+  isLoggedIn(): boolean {
+    return !!this.getToken();
+  }
+
+  getRoles(): string[] {
+    const token = this.getToken();
+    if (!token) return [];
+    try {
+      const payload = JSON.parse(atob(token.split('.')[1]));
+      return payload['roles'] || [];
+    } catch {
+      return [];
+    }
+  }
+
+  hasRole(role: string): boolean {
+    return this.getRoles().includes(role);
+  }
+}

--- a/frontend/src/app/services/pedido.service.ts
+++ b/frontend/src/app/services/pedido.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+export interface Pedido {
+  id: string;
+  clienteId: string;
+  total: number;
+  estado: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class PedidoService {
+  private api = 'http://localhost:8080/api/pedidos';
+
+  constructor(private http: HttpClient) {}
+
+  crear(pedido: { clienteId: string; total: number }): Observable<Pedido> {
+    return this.http.post<Pedido>(this.api, pedido);
+  }
+
+  listarPorCliente(clienteId: string): Observable<Pedido[]> {
+    return this.http.get<Pedido[]>(`${this.api}/cliente/${clienteId}`);
+  }
+
+  ver(id: string): Observable<Pedido> {
+    return this.http.get<Pedido>(`${this.api}/${id}`);
+  }
+}

--- a/frontend/src/app/services/tracking.service.ts
+++ b/frontend/src/app/services/tracking.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+export interface TrackingEntry {
+  pedidoId: string;
+  clienteId: string;
+  estado: string;
+  total: number;
+}
+
+@Injectable({ providedIn: 'root' })
+export class TrackingService {
+  private api = 'http://localhost:8080/api/tracking';
+
+  constructor(private http: HttpClient) {}
+
+  obtener(pedidoId: string): Observable<TrackingEntry> {
+    return this.http.get<TrackingEntry>(`${this.api}/${pedidoId}`);
+  }
+}

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Sistema de Pedidos</title>
+  <base href="/">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body>
+  <app-root>Loading...</app-root>
+</body>
+</html>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,0 +1,5 @@
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { AppModule } from './app/app.module';
+
+platformBrowserDynamic().bootstrapModule(AppModule)
+  .catch(err => console.error(err));

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,4 @@
+body { font-family: Arial, sans-serif; margin: 0; padding: 0; }
+nav { background: #1976d2; color: white; padding: 0.5rem 1rem; }
+nav a { color: white; margin-right: 1rem; text-decoration: none; }
+.alert { color: red; font-weight: bold; }

--- a/frontend/src/test.ts
+++ b/frontend/src/test.ts
@@ -1,0 +1,8 @@
+import 'zone.js/testing';
+import { getTestBed } from '@angular/core/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting
+} from '@angular/platform-browser-dynamic/testing';
+
+getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/out-tsc/app",
+    "types": []
+  },
+  "files": ["src/main.ts"],
+  "include": ["src/**/*.d.ts"]
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "./dist/out-tsc",
+    "sourceMap": true,
+    "declaration": false,
+    "module": "es2022",
+    "moduleResolution": "node",
+    "experimentalDecorators": true,
+    "target": "es2022",
+    "typeRoots": ["node_modules/@types"],
+    "lib": ["es2022", "dom"]
+  }
+}

--- a/frontend/tsconfig.spec.json
+++ b/frontend/tsconfig.spec.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/out-tsc/spec",
+    "types": ["jasmine"]
+  },
+  "files": ["src/test.ts"],
+  "include": ["src/**/*.spec.ts", "src/**/*.d.ts"]
+}


### PR DESCRIPTION
## Summary
- scaffold Angular client to interact with microservices
- add OAuth2 login, token interceptor and route guards
- implement forms and views for pedidos and tracking with consistency indicator

## Testing
- `npm test` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aad89f87a88324bcbff1a4fcf35f8a