### PR TITLE
Add Docker Compose to run backend and frontend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,142 @@
+name: proy-unidad
+
+networks:
+  appnet:
+    name: appnet
+  cliente-dbnet:
+    internal: true
+  pedido-dbnet:
+    internal: true
+  tracking-dbnet:
+    internal: true
+
+volumes:
+  clientes-data:
+  pedidos-data:
+
+services:
+  api-gateway:
+    build: ./back-end/api-gateway
+    container_name: api-gateway
+    environment:
+      SPRING_PROFILES_ACTIVE: docker
+      AUTH_ISSUER_URI: http://auth-service:9000
+      CLIENTES_BASE_URL: http://cliente-service:8080
+      PEDIDOS_BASE_URL:  http://pedido-service:8080
+      TRACKING_BASE_URL: http://tracking-service:8080
+      CORS_ALLOWED_ORIGINS: http://localhost:4200,http://localhost:8080
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    ports:
+      - "8080:8080"
+    depends_on:
+      - auth-service
+      - cliente-service
+      - pedido-service
+      - tracking-service
+    networks:
+      - appnet
+
+  auth-service:
+    build: ./back-end/auth-service
+    container_name: auth-service
+    environment:
+      SPRING_PROFILES_ACTIVE: docker
+      APP_ISSUER: http://auth-service:9000
+    ports:
+      - "9000:9000"
+    networks:
+      - appnet
+
+  cliente-service:
+    build: ./back-end/cliente-service
+    container_name: cliente-service
+    environment:
+      SPRING_PROFILES_ACTIVE: docker
+      SPRING_DATASOURCE_URL: jdbc:postgresql://clientes-db:5432/clientes
+      SPRING_DATASOURCE_USERNAME: postgres
+      SPRING_DATASOURCE_PASSWORD: postgres
+    ports:
+      - "8081:8080"
+    depends_on:
+      - clientes-db
+    networks:
+      - appnet
+      - cliente-dbnet
+
+  clientes-db:
+    image: postgres:16
+    container_name: clientes-db
+    environment:
+      POSTGRES_DB: clientes
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5433:5432"
+    volumes:
+      - clientes-data:/var/lib/postgresql/data
+    networks:
+      - cliente-dbnet
+
+  pedido-service:
+    build: ./back-end/pedido-service
+    container_name: pedido-service
+    environment:
+      SPRING_PROFILES_ACTIVE: docker
+      SPRING_DATASOURCE_URL: jdbc:mysql://pedidos-db:3306/pedidos?allowPublicKeyRetrieval=true&useSSL=false
+      SPRING_DATASOURCE_USERNAME: root
+      SPRING_DATASOURCE_PASSWORD: root
+    ports:
+      - "8082:8080"
+    depends_on:
+      - pedidos-db
+    networks:
+      - appnet
+      - pedido-dbnet
+
+  pedidos-db:
+    image: mysql:8.4
+    container_name: pedidos-db
+    environment:
+      MYSQL_DATABASE: pedidos
+      MYSQL_ROOT_PASSWORD: root
+    ports:
+      - "3307:3306"
+    volumes:
+      - pedidos-data:/var/lib/mysql
+    networks:
+      - pedido-dbnet
+
+  tracking-service:
+    build: ./back-end/tracking-service
+    container_name: tracking-service
+    environment:
+      SPRING_PROFILES_ACTIVE: docker
+      SPRING_REDIS_HOST: tracking-redis
+      SPRING_REDIS_PORT: 6379
+    ports:
+      - "8083:8080"
+    depends_on:
+      - tracking-redis
+    networks:
+      - appnet
+      - tracking-dbnet
+
+  tracking-redis:
+    image: redis:7.2-alpine
+    container_name: tracking-redis
+    ports:
+      - "6380:6379"
+    networks:
+      - tracking-dbnet
+
+  frontend:
+    build: ./frontend
+    container_name: frontend
+    ports:
+      - "4200:80"
+    depends_on:
+      - api-gateway
+    networks:
+      - appnet
+

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,13 @@
+# Stage 1: build the angular app
+FROM node:20 AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+# Stage 2: serve the app with nginx
+FROM nginx:alpine
+COPY --from=build /app/dist/pedido-frontend /usr/share/nginx/html
+EXPOSE 80
+


### PR DESCRIPTION
## Summary
- Add root docker-compose that starts all backend services and frontend
- Add multi-stage Dockerfile to build and serve Angular frontend

## Testing
- `npm --prefix frontend install --no-audit --no-fund` *(fails: ENOTEMPTY: directory not empty, rename)*
- `npm --prefix frontend test -- --watch=false --browsers=ChromeHeadless` *(fails: ng: not found)*
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2744e3388324b5b55b015e98d50f