### PR TITLE
chore: add root dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,73 @@
+# === Git ===
+.git
+.gitignore
+
+# === Archivos y carpetas de sistema ===
+.DS_Store
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+
+# === Configuración de IDEs ===
+.vscode/
+.idea/
+*.iml
+*.swp
+
+# === Node.js / Angular ====
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+dist/
+build/
+.tmp/
+.angular/
+.angular/cache/
+frontend/.angular/
+frontend/dist/
+frontend/node_modules/
+
+# === Java / Spring Boot ===
+target/
+out/
+*.class
+*.jar
+*.war
+*.ear
+
+# === Logs y temporales ===
+*.log
+*.pid
+*.seed
+*.pid.lock
+*.tmp
+
+# === Entornos virtuales Python (si usas) ===
+.venv/
+venv/
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+
+# === Docker ===
+docker-compose.override.yml
+.docker/
+*.env
+
+# === Cobertura y testing ===
+coverage/
+.nyc_output/
+.junit/
+.test/
+.jest/
+
+# === SonarQube ===
+.sonar/
+.scannerwork/
+
+# === Archivos de bases de datos locales ===
+*.db
+*.sqlite
+*.sql


### PR DESCRIPTION
## Summary
- ignore build and env artifacts in a new `.dockerignore`

## Testing
- `npm test` *(fails: package.json not found)*
- `(cd frontend && npm test)` *(fails: ng not found)*
- `(cd tracking-frontend && npm test)` *(fails: package.json not found)*
- `(cd back-end/api-gateway && mvn -q test)` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2e58067c8324a13032b433d6b949