### PR TITLE
Enable CORS in microservices

### DIFF
--- a/back-end/cliente-service/src/main/java/com/example/cliente_service/config/CorsConfig.java
+++ b/back-end/cliente-service/src/main/java/com/example/cliente_service/config/CorsConfig.java
@@ -1,0 +1,23 @@
+package com.example.cliente_service.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig {
+  @Bean
+  public WebMvcConfigurer corsConfigurer() {
+    return new WebMvcConfigurer() {
+      @Override
+      public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+            .allowedOrigins("http://localhost:4200")
+            .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+            .allowedHeaders("*")
+            .allowCredentials(true);
+      }
+    };
+  }
+}

--- a/back-end/cliente-service/src/main/java/com/example/cliente_service/config/SecurityConfig.java
+++ b/back-end/cliente-service/src/main/java/com/example/cliente_service/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.example.cliente_service.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -13,6 +14,7 @@ public class SecurityConfig {
   SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
     http
       .csrf(AbstractHttpConfigurer::disable)
+      .cors(Customizer.withDefaults())
       .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
       .httpBasic(AbstractHttpConfigurer::disable)
       .formLogin(AbstractHttpConfigurer::disable)

--- a/back-end/pedido-service/src/main/java/com/example/pedido_service/config/CorsConfig.java
+++ b/back-end/pedido-service/src/main/java/com/example/pedido_service/config/CorsConfig.java
@@ -1,0 +1,23 @@
+package com.example.pedido_service.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig {
+  @Bean
+  public WebMvcConfigurer corsConfigurer() {
+    return new WebMvcConfigurer() {
+      @Override
+      public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+            .allowedOrigins("http://localhost:4200")
+            .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+            .allowedHeaders("*")
+            .allowCredentials(true);
+      }
+    };
+  }
+}

--- a/back-end/pedido-service/src/main/java/com/example/pedido_service/config/SecurityConfig.java
+++ b/back-end/pedido-service/src/main/java/com/example/pedido_service/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.example.pedido_service.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -13,6 +14,7 @@ public class SecurityConfig {
   SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
     http
       .csrf(AbstractHttpConfigurer::disable)
+      .cors(Customizer.withDefaults())
       .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
       .httpBasic(AbstractHttpConfigurer::disable)
       .formLogin(AbstractHttpConfigurer::disable)

--- a/back-end/tracking-service/src/main/java/com/example/tracking_service/config/CorsConfig.java
+++ b/back-end/tracking-service/src/main/java/com/example/tracking_service/config/CorsConfig.java
@@ -1,0 +1,23 @@
+package com.example.tracking_service.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig {
+  @Bean
+  public WebMvcConfigurer corsConfigurer() {
+    return new WebMvcConfigurer() {
+      @Override
+      public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+            .allowedOrigins("http://localhost:4200")
+            .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+            .allowedHeaders("*")
+            .allowCredentials(true);
+      }
+    };
+  }
+}

--- a/back-end/tracking-service/src/main/java/com/example/tracking_service/config/SecurityConfig.java
+++ b/back-end/tracking-service/src/main/java/com/example/tracking_service/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.example.tracking_service.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -13,6 +14,7 @@ public class SecurityConfig {
   SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
     http
       .csrf(AbstractHttpConfigurer::disable)
+      .cors(Customizer.withDefaults())
       .authorizeHttpRequests(auth -> auth
         .requestMatchers("/api/tracking/**","/actuator/**").permitAll()
         .requestMatchers("/internal/**").hasAuthority("SCOPE_tracking.write")


### PR DESCRIPTION
## Summary
- Enable CORS handling in security filter chains for cliente, pedido, and tracking services
- Add global CORS configuration allowing http://localhost:4200 for REST endpoints

## Testing
- `mvn -q -f back-end/cliente-service/pom.xml test` *(fails: Non-resolvable parent POM, network unreachable)*
- `mvn -q -f back-end/pedido-service/pom.xml test` *(fails: Non-resolvable parent POM, network unreachable)*
- `mvn -q -f back-end/tracking-service/pom.xml test` *(fails: Non-resolvable parent POM, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ab40f3a10083248f0f7d6e6ade78cc