### PR TITLE
Allow React dev origin in CORS configuration

### DIFF
--- a/back-end/api-gateway/src/main/java/com/example/gateway/security/SecurityConfig.java
+++ b/back-end/api-gateway/src/main/java/com/example/gateway/security/SecurityConfig.java
@@ -106,7 +106,7 @@ public class SecurityConfig {
     // Permite configurar orígenes por env. Por defecto, sólo Angular dev.
     String allowedCsv = System.getenv().getOrDefault(
       "CORS_ALLOWED_ORIGINS",
-      "http://localhost:4200"
+      "http://localhost:4200,http://localhost:3000"
     );
 
     CorsConfiguration cfg = new CorsConfiguration();

--- a/back-end/auth-service/src/main/java/com/example/auth_service/config/SecurityConfig.java
+++ b/back-end/auth-service/src/main/java/com/example/auth_service/config/SecurityConfig.java
@@ -181,7 +181,7 @@ public class SecurityConfig {
   @Bean
   CorsConfigurationSource corsConfigurationSource() {
     CorsConfiguration cfg = new CorsConfiguration();
-    cfg.setAllowedOrigins(List.of("http://localhost:4200"));
+    cfg.setAllowedOrigins(List.of("http://localhost:4200", "http://localhost:3000"));
     cfg.setAllowedMethods(List.of("GET","POST","PUT","DELETE","OPTIONS"));
     cfg.setAllowedHeaders(List.of("Authorization","Content-Type","Cache-Control","X-Requested-With"));
     cfg.setExposedHeaders(List.of("Location"));


### PR DESCRIPTION
## Summary
- allow http://localhost:3000 in auth-service CORS config
- expose default CORS origin for React dev in API gateway

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.example:auth-service:0.0.1-SNAPSHOT – Network is unreachable)*
- `mvn -q test` *(fails: Non-resolvable parent POM for com.example:api-gateway:0.0.1-SNAPSHOT – Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5f419b2c8324a954015dd8575e88