### PR TITLE
Implement PKCE flow and secure pedido service

### DIFF
--- a/back-end/auth-service/src/main/java/com/example/auth_service/config/SecurityConfig.java
+++ b/back-end/auth-service/src/main/java/com/example/auth_service/config/SecurityConfig.java
@@ -30,6 +30,8 @@ import org.springframework.security.oauth2.server.authorization.settings.ClientS
 import org.springframework.security.oauth2.server.authorization.settings.TokenSettings;
 import org.springframework.security.oauth2.server.authorization.token.JwtEncodingContext;
 import org.springframework.security.oauth2.server.authorization.token.OAuth2TokenCustomizer;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -65,7 +67,7 @@ public class SecurityConfig {
       .authorizeHttpRequests(auth -> auth
         .requestMatchers("/actuator/**", "/auth/register", "/auth/login").permitAll()
         .anyRequest().authenticated())
-      .formLogin(Customizer.withDefaults());
+      .formLogin(AbstractHttpConfigurer::disable);
     return http.build();
   }
 
@@ -169,6 +171,11 @@ public class SecurityConfig {
     RSAKey rsaKey = Jwks.generateRsa();
     JWKSet jwkSet = new JWKSet(rsaKey);
     return (jwkSelector, securityContext) -> jwkSelector.select(jwkSet);
+  }
+
+  @Bean
+  JwtEncoder jwtEncoder(JWKSource<SecurityContext> jwkSource) {
+    return new NimbusJwtEncoder(jwkSource);
   }
 
   // --- Issuer ---

--- a/back-end/auth-service/src/main/java/com/example/auth_service/controller/AuthController.java
+++ b/back-end/auth-service/src/main/java/com/example/auth_service/controller/AuthController.java
@@ -8,11 +8,19 @@ import com.example.auth_service.user.AppUserRepository;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Instant;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/auth")
@@ -21,34 +29,50 @@ public class AuthController {
   private final PasswordEncoder passwordEncoder;
   private final AppUserRepository userRepository;
   private final AuthenticationManager authenticationManager;
+  private final JwtEncoder jwtEncoder;
 
   public AuthController(PasswordEncoder passwordEncoder,
                         AppUserRepository userRepository,
-                        AuthenticationManager authenticationManager) {
+                        AuthenticationManager authenticationManager,
+                        JwtEncoder jwtEncoder) {
     this.passwordEncoder = passwordEncoder;
     this.userRepository = userRepository;
     this.authenticationManager = authenticationManager;
+    this.jwtEncoder = jwtEncoder;
   }
 
   @PostMapping("/register")
   public ResponseEntity<AuthResponse> register(@RequestBody RegisterRequest request) {
-    if (userRepository.existsByUsername(request.username())) {
-      return ResponseEntity.badRequest().body(new AuthResponse("User already exists"));
-    }
+      if (userRepository.existsByUsername(request.username())) {
+        return ResponseEntity.badRequest().body(new AuthResponse("User already exists", null, null));
+      }
     AppUser user = AppUser.builder()
         .username(request.username())
         .password(passwordEncoder.encode(request.password()))
         .role(request.role().toUpperCase())
         .build();
     userRepository.save(user);
-    return ResponseEntity.ok(new AuthResponse("User registered"));
+    return ResponseEntity.ok(new AuthResponse("User registered", null, null));
   }
 
   @PostMapping("/login")
   public ResponseEntity<AuthResponse> login(@RequestBody LoginRequest request) {
     UsernamePasswordAuthenticationToken token =
         new UsernamePasswordAuthenticationToken(request.username(), request.password());
-    authenticationManager.authenticate(token);
-    return ResponseEntity.ok(new AuthResponse("Login successful"));
+    Authentication auth = authenticationManager.authenticate(token);
+
+    Instant now = Instant.now();
+    JwtClaimsSet claims = JwtClaimsSet.builder()
+        .issuer("self")
+        .issuedAt(now)
+        .expiresAt(now.plusSeconds(3600))
+        .subject(request.username())
+        .claim("roles", auth.getAuthorities().stream()
+            .map(GrantedAuthority::getAuthority)
+            .collect(Collectors.toList()))
+        .build();
+    String accessToken = jwtEncoder.encode(JwtEncoderParameters.from(claims)).getTokenValue();
+
+    return ResponseEntity.ok(new AuthResponse("Login successful", accessToken, null));
   }
 }

--- a/back-end/auth-service/src/main/java/com/example/auth_service/dto/AuthResponse.java
+++ b/back-end/auth-service/src/main/java/com/example/auth_service/dto/AuthResponse.java
@@ -1,3 +1,3 @@
 package com.example.auth_service.dto;
 
-public record AuthResponse(String message) {}
+public record AuthResponse(String message, String accessToken, String refreshToken) {}

--- a/back-end/pedido-service/pom.xml
+++ b/back-end/pedido-service/pom.xml
@@ -50,6 +50,10 @@
       <artifactId>spring-boot-starter-security</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.flywaydb</groupId>
       <artifactId>flyway-core</artifactId>
     </dependency>

--- a/back-end/pedido-service/src/main/java/com/example/pedido_service/config/SecurityConfig.java
+++ b/back-end/pedido-service/src/main/java/com/example/pedido_service/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.example.pedido_service.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -15,9 +16,13 @@ public class SecurityConfig {
     http
       .csrf(AbstractHttpConfigurer::disable)
       .cors(Customizer.withDefaults())
-      .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
-      .httpBasic(AbstractHttpConfigurer::disable)
-      .formLogin(AbstractHttpConfigurer::disable)
+      .authorizeHttpRequests(auth -> auth
+        .requestMatchers(HttpMethod.GET, "/api/pedidos/**").hasAuthority("SCOPE_pedidos.read")
+        .requestMatchers(HttpMethod.POST, "/api/pedidos/**").hasAuthority("SCOPE_pedidos.write")
+        .requestMatchers(HttpMethod.PUT, "/api/pedidos/**").hasAuthority("SCOPE_pedidos.write")
+        .requestMatchers(HttpMethod.DELETE, "/api/pedidos/**").hasAuthority("SCOPE_pedidos.write")
+        .anyRequest().authenticated())
+      .oauth2ResourceServer(oauth2 -> oauth2.jwt())
       .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
     return http.build();
   }

--- a/back-end/pedido-service/src/main/resources/application.yml
+++ b/back-end/pedido-service/src/main/resources/application.yml
@@ -3,6 +3,11 @@ spring:
     name: pedido-service
   jpa:
     open-in-view: false
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: http://localhost:9000
 
 server:
   port: 8080
@@ -39,6 +44,11 @@ spring:
     baseline-on-migrate: true
     locations: classpath:/db/migration
     encoding: UTF-8
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: http://auth-service:9000
 
 tracking:
   base-url: http://tracking-service:8080

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { LoginComponent } from './pages/login.component';
+import { CallbackComponent } from './pages/callback.component';
 import { PedidoFormComponent } from './components/pedido-form.component';
 import { PedidoListComponent } from './components/pedido-list.component';
 import { TrackingComponent } from './components/tracking.component';
@@ -9,6 +10,7 @@ import { RoleGuard } from './guards/role.guard';
 
 const routes: Routes = [
   { path: 'login', component: LoginComponent },
+  { path: 'callback', component: CallbackComponent },
   {
     path: 'nuevo',
     component: PedidoFormComponent,

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -7,6 +7,7 @@ import { RouterModule } from '@angular/router';
 import { AppComponent } from './app.component';
 import { AppRoutingModule } from './app-routing.module';
 import { LoginComponent } from './pages/login.component';
+import { CallbackComponent } from './pages/callback.component';
 import { PedidoFormComponent } from './components/pedido-form.component';
 import { PedidoListComponent } from './components/pedido-list.component';
 import { TrackingComponent } from './components/tracking.component';
@@ -16,6 +17,7 @@ import { AuthInterceptor } from './interceptors/auth.interceptor';
   declarations: [
     AppComponent,
     LoginComponent,
+    CallbackComponent,
     PedidoFormComponent,
     PedidoListComponent,
     TrackingComponent

--- a/frontend/src/app/pages/callback.component.ts
+++ b/frontend/src/app/pages/callback.component.ts
@@ -1,0 +1,18 @@
+import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { AuthService } from '../services/auth.service';
+
+@Component({
+  selector: 'app-callback',
+  template: `<p>Procesando autenticación...</p>`
+})
+export class CallbackComponent implements OnInit {
+  constructor(private auth: AuthService, private router: Router) {}
+
+  ngOnInit(): void {
+    this.auth.handleAuthCallback().subscribe({
+      next: () => this.router.navigate(['/mis-pedidos']),
+      error: () => this.router.navigate(['/login'])
+    });
+  }
+}

--- a/frontend/src/app/pages/login.component.ts
+++ b/frontend/src/app/pages/login.component.ts
@@ -1,32 +1,20 @@
 import { Component } from '@angular/core';
-import { Router } from '@angular/router';
 import { AuthService } from '../services/auth.service';
 
 @Component({
   selector: 'app-login',
   template: `
     <h2>Login</h2>
-    <form (ngSubmit)="submit()">
-      <label>Email</label>
-      <input [(ngModel)]="username" name="username" required />
-      <label>Password</label>
-      <input [(ngModel)]="password" name="password" type="password" required />
-      <button type="submit">Ingresar</button>
-    </form>
+    <button (click)="login()">Ingresar</button>
     <div *ngIf="error" class="alert">{{ error }}</div>
   `
 })
 export class LoginComponent {
-  username = '';
-  password = '';
   error: string | null = null;
 
-  constructor(private auth: AuthService, private router: Router) {}
+  constructor(private auth: AuthService) {}
 
-  submit() {
-    this.auth.login(this.username, this.password).subscribe({
-      next: () => this.router.navigate(['/mis-pedidos']),
-      error: () => (this.error = 'Credenciales inválidas')
-    });
+  login() {
+    this.auth.login().catch(() => (this.error = 'Error de autenticación'));
   }
 }

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -3,31 +3,71 @@ import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Router } from '@angular/router';
 import { tap } from 'rxjs/operators';
 
+function base64UrlEncode(arrayBuffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(arrayBuffer);
+  let binary = '';
+  bytes.forEach(b => (binary += String.fromCharCode(b)));
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
 @Injectable({ providedIn: 'root' })
 export class AuthService {
   private tokenKey = 'auth_token';
+  private refreshKey = 'refresh_token';
+  private verifierKey = 'pkce_code_verifier';
   private api = 'http://localhost:8080'; // gateway
+  private redirectUri = 'http://localhost:4200/callback';
 
   constructor(private http: HttpClient, private router: Router) {}
 
-  login(username: string, password: string) {
+  private generateCodeVerifier(): string {
+    const array = new Uint8Array(64);
+    window.crypto.getRandomValues(array);
+    return Array.from(array, b => ('0' + b.toString(16)).slice(-2)).join('');
+  }
+
+  private async generateCodeChallenge(verifier: string): Promise<string> {
+    const data = new TextEncoder().encode(verifier);
+    const digest = await window.crypto.subtle.digest('SHA-256', data);
+    return base64UrlEncode(digest);
+  }
+
+  async login(): Promise<void> {
+    const verifier = this.generateCodeVerifier();
+    sessionStorage.setItem(this.verifierKey, verifier);
+    const challenge = await this.generateCodeChallenge(verifier);
+    const authUrl = `${this.api}/oauth2/authorize?response_type=code&client_id=front-client&redirect_uri=${encodeURIComponent(this.redirectUri)}&scope=openid%20profile%20pedidos.read%20pedidos.write&code_challenge=${challenge}&code_challenge_method=S256`;
+    window.location.href = authUrl;
+  }
+
+  handleAuthCallback() {
+    const params = new URLSearchParams(window.location.search);
+    const code = params.get('code');
+    const verifier = sessionStorage.getItem(this.verifierKey) || '';
     const body = new URLSearchParams();
-    body.set('grant_type', 'password');
-    body.set('username', username);
-    body.set('password', password);
-
+    body.set('grant_type', 'authorization_code');
+    body.set('code', code || '');
+    body.set('redirect_uri', this.redirectUri);
+    body.set('client_id', 'front-client');
+    body.set('code_verifier', verifier);
     const headers = new HttpHeaders({
-      'Content-Type': 'application/x-www-form-urlencoded',
-      Authorization: 'Basic ' + btoa('front-client:')
+      'Content-Type': 'application/x-www-form-urlencoded'
     });
-
     return this.http
       .post<any>(`${this.api}/oauth2/token`, body.toString(), { headers })
-      .pipe(tap(res => localStorage.setItem(this.tokenKey, res.access_token)));
+      .pipe(
+        tap(res => {
+          localStorage.setItem(this.tokenKey, res.access_token);
+          if (res.refresh_token) {
+            localStorage.setItem(this.refreshKey, res.refresh_token);
+          }
+        })
+      );
   }
 
   logout() {
     localStorage.removeItem(this.tokenKey);
+    localStorage.removeItem(this.refreshKey);
     this.router.navigate(['/login']);
   }
 


### PR DESCRIPTION
## Summary
- Add PKCE-based OAuth2 login in Angular app with callback handling
- Issue JWT tokens on login and disable form login in auth-service
- Protect pedido-service endpoints with JWT resource server

## Testing
- `npm test -- --watch=false` *(fails: Cannot find module 'karma')*
- `mvn -q test` in `back-end/auth-service` *(fails: Could not transfer artifact due to network unreachable)*
- `mvn -q test` in `back-end/pedido-service` *(fails: Could not transfer artifact due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ab612fe064832481507d404da0f9f9