### PR TITLE
Handle default role during user registration

### DIFF
--- a/back-end/auth-service/src/main/java/com/example/auth_service/controller/AuthController.java
+++ b/back-end/auth-service/src/main/java/com/example/auth_service/controller/AuthController.java
@@ -46,10 +46,15 @@ public class AuthController {
       if (userRepository.existsByUsername(request.username())) {
         return ResponseEntity.badRequest().body(new AuthResponse("User already exists", null, null));
       }
+
+    String role = request.role() == null || request.role().isBlank()
+        ? "CLIENTE"
+        : request.role().toUpperCase();
+
     AppUser user = AppUser.builder()
         .username(request.username())
         .password(passwordEncoder.encode(request.password()))
-        .role(request.role().toUpperCase())
+        .role(role)
         .build();
     userRepository.save(user);
     return ResponseEntity.ok(new AuthResponse("User registered", null, null));

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -32,7 +32,7 @@ export class AuthService {
   }
 
   register(username: string, password: string) {
-    return this.http.post(`${this.authApi}/register`, { username, password });
+    return this.http.post(`${this.authApi}/register`, { username, password, role: 'CLIENTE' });
   }
 
   getToken(): string | null {


### PR DESCRIPTION
## Summary
- Default missing user roles to CLIENTE in the auth service
- Send CLIENTE role during frontend registration

## Testing
- `mvn -q test` *(fails: Could not resolve parent POM org.springframework.boot:spring-boot-starter-parent)*
- `npm test -- --watch=false --progress=false --browsers=ChromeHeadless` *(fails: Cannot find module 'karma')*


------
https://chatgpt.com/codex/tasks/task_e_68ab80ce1cfc832493624d38ecb2ce3d