### PR TITLE
feat: track order update timestamp

### DIFF
--- a/back-end/pedido-service/src/main/java/com/example/pedido_service/pedidos/PedidoController.java
+++ b/back-end/pedido-service/src/main/java/com/example/pedido_service/pedidos/PedidoController.java
@@ -51,6 +51,7 @@ public class PedidoController {
         .clienteId(saved.getClienteId())
         .estado(saved.getEstado())
         .total(saved.getTotal())
+        .actualizadoEn(saved.getActualizadoEn())
         .build());
     return PedidoRes.of(saved);
   }
@@ -67,6 +68,7 @@ public class PedidoController {
         .clienteId(updated.getClienteId())
         .estado(updated.getEstado())
         .total(updated.getTotal())
+        .actualizadoEn(updated.getActualizadoEn())
         .build());
     return PedidoRes.of(updated);
   }

--- a/back-end/pedido-service/src/main/java/com/example/pedido_service/tracking/TrackingPayload.java
+++ b/back-end/pedido-service/src/main/java/com/example/pedido_service/tracking/TrackingPayload.java
@@ -4,6 +4,7 @@ import com.example.pedido_service.pedidos.PedidoEstado;
 import lombok.*;
 
 import java.math.BigDecimal;
+import java.time.OffsetDateTime;
 import java.util.UUID;
 
 @Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
@@ -12,4 +13,5 @@ public class TrackingPayload {
   private UUID clienteId;
   private PedidoEstado estado;
   private BigDecimal total;
+  private OffsetDateTime actualizadoEn;
 }

--- a/back-end/tracking-service/src/main/java/com/example/tracking_service/tracking/TrackingEntry.java
+++ b/back-end/tracking-service/src/main/java/com/example/tracking_service/tracking/TrackingEntry.java
@@ -19,5 +19,6 @@ public class TrackingEntry {
   private PedidoEstado estado;
   @NotNull
   private BigDecimal total;
+  @NotNull
   private OffsetDateTime actualizadoEn;
 }

--- a/frontend/src/app/components/tracking.component.ts
+++ b/frontend/src/app/components/tracking.component.ts
@@ -51,7 +51,9 @@ export class TrackingComponent {
     if (this.pedido && this.tracking) {
       this.discrepancia =
         this.pedido.estado !== this.tracking.estado ||
-        this.pedido.total !== this.tracking.total;
+        this.pedido.total !== this.tracking.total ||
+        new Date(this.tracking.actualizadoEn).getTime() <
+          new Date(this.pedido.actualizadoEn).getTime();
     }
   }
 }

--- a/frontend/src/app/services/pedido.service.ts
+++ b/frontend/src/app/services/pedido.service.ts
@@ -7,6 +7,8 @@ export interface Pedido {
   clienteId: string;
   total: number;
   estado: string;
+  creadoEn: string;
+  actualizadoEn: string;
 }
 
 @Injectable({ providedIn: 'root' })

--- a/frontend/src/app/services/tracking.service.ts
+++ b/frontend/src/app/services/tracking.service.ts
@@ -7,6 +7,7 @@ export interface TrackingEntry {
   clienteId: string;
   estado: string;
   total: number;
+  actualizadoEn: string;
 }
 
 @Injectable({ providedIn: 'root' })


### PR DESCRIPTION
## Summary
- include `actualizadoEn` in tracking payload and propagate from pedido-service
- expose updated timestamp in tracking service for comparison
- show stale tracking information in Angular tracking component

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*
- `npm test -- --watch=false` *(fails: Cannot find module 'karma')*


------
https://chatgpt.com/codex/tasks/task_e_68ab88c173c88324b90065dc12ba4445