### PR TITLE
feat: mejorar panel de operador

### DIFF
--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -6,6 +6,7 @@ import { ProductsComponent } from './pages/products.component';
 import { PedidoFormComponent } from './components/pedido-form.component';
 import { PedidoListComponent } from './components/pedido-list.component';
 import { TrackingComponent } from './components/tracking.component';
+import { OperatorDashboardComponent } from './components/operator-dashboard/operator-dashboard.component';
 import { AuthGuard } from './guards/auth.guard';
 import { RoleGuard } from './guards/role.guard';
 
@@ -29,6 +30,12 @@ const routes: Routes = [
     component: TrackingComponent,
     canActivate: [AuthGuard, RoleGuard],
     data: { role: 'CLIENTE' }
+  },
+  {
+    path: 'operador/ordenes',
+    component: OperatorDashboardComponent,
+    canActivate: [AuthGuard, RoleGuard],
+    data: { role: 'OPERADOR' }
   },
   { path: '', component: ProductsComponent }
 ];

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -1,6 +1,7 @@
 <header>
   <button routerLink="/login">Login</button>
   <button routerLink="/register">Register</button>
+  <button routerLink="/operador/ordenes">Operador</button>
   <button *ngIf="auth.isLoggedIn()" (click)="logout()">Logout</button>
 </header>
 <main>

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -12,6 +12,7 @@ import { ProductsComponent } from './pages/products.component';
 import { PedidoFormComponent } from './components/pedido-form.component';
 import { PedidoListComponent } from './components/pedido-list.component';
 import { TrackingComponent } from './components/tracking.component';
+import { OperatorDashboardComponent } from './components/operator-dashboard/operator-dashboard.component';
 import { AuthInterceptor } from './interceptors/auth.interceptor';
 
 @NgModule({
@@ -22,7 +23,8 @@ import { AuthInterceptor } from './interceptors/auth.interceptor';
     ProductsComponent,
     PedidoFormComponent,
     PedidoListComponent,
-    TrackingComponent
+    TrackingComponent,
+    OperatorDashboardComponent
   ],
   imports: [
     BrowserModule,

--- a/frontend/src/app/components/operator-dashboard/operator-dashboard.component.css
+++ b/frontend/src/app/components/operator-dashboard/operator-dashboard.component.css
@@ -1,0 +1,325 @@
+:host {
+  display: block;
+  background: linear-gradient(180deg, #f7e4e4 0%, #ffffff 120%);
+  min-height: 100vh;
+  padding: 1.5rem 2rem 3rem;
+  box-sizing: border-box;
+}
+
+.operator-dashboard {
+  display: grid;
+  grid-template-columns: minmax(210px, 260px) minmax(0, 1fr);
+  gap: 2.5rem;
+  align-items: start;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.operator-menu {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 16px;
+  box-shadow: 0 16px 40px rgba(127, 17, 17, 0.08);
+  padding: 1.75rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.operator-menu h2 {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #861414;
+}
+
+.operator-menu p {
+  margin: 0;
+  color: #5f3a3a;
+  font-size: 0.9rem;
+}
+
+.operator-menu nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.menu-button {
+  width: 100%;
+  border: none;
+  border-radius: 999px;
+  padding: 0.75rem 1.25rem;
+  font-weight: 600;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+  background: rgba(186, 33, 46, 0.12);
+  color: #7a1420;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.menu-button.active,
+.menu-button:hover {
+  background: #ba212e;
+  color: #fff;
+}
+
+.operator-content {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.content-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.5rem;
+}
+
+.content-header h1 {
+  margin: 0;
+  font-size: 1.75rem;
+  color: #5c131a;
+}
+
+.content-header p {
+  margin: 0.25rem 0 0;
+  color: #7c5158;
+}
+
+.session-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.75rem;
+  color: #5c131a;
+  font-weight: 600;
+}
+
+.orders-card,
+.order-edit {
+  background: rgba(255, 255, 255, 0.96);
+  border-radius: 18px;
+  box-shadow: 0 18px 45px rgba(124, 33, 42, 0.12);
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.orders-card header,
+.order-edit header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.orders-card header h2,
+.order-edit header h2 {
+  margin: 0;
+  font-size: 1.35rem;
+  color: #6d1a22;
+}
+
+.status-selector {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.status-selector label {
+  font-weight: 600;
+  color: #5c131a;
+}
+
+.status-selector select {
+  min-width: 160px;
+  border-radius: 999px;
+  border: 1px solid rgba(122, 20, 32, 0.25);
+  padding: 0.5rem 1rem;
+  background: #fff;
+  color: #5c131a;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+thead {
+  text-align: left;
+  color: #7c5158;
+  font-size: 0.85rem;
+}
+
+thead th {
+  font-weight: 600;
+  padding-bottom: 0.75rem;
+}
+
+tbody td {
+  padding: 0.65rem 0;
+  border-top: 1px solid rgba(122, 20, 32, 0.12);
+  color: #44282b;
+}
+
+td.actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.primary,
+.secondary {
+  border-radius: 999px;
+  padding: 0.55rem 1.5rem;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primary {
+  background: #ba212e;
+  color: #fff;
+}
+
+.primary:hover {
+  box-shadow: 0 8px 18px rgba(186, 33, 46, 0.25);
+}
+
+.secondary {
+  background: rgba(186, 33, 46, 0.12);
+  color: #7a1420;
+}
+
+.secondary:hover {
+  background: rgba(186, 33, 46, 0.2);
+}
+
+.tasks-table {
+  display: flex;
+  flex-direction: column;
+  border-radius: 14px;
+  border: 1px solid rgba(122, 20, 32, 0.12);
+  overflow: hidden;
+}
+
+.tasks-row {
+  display: grid;
+  grid-template-columns: 2fr repeat(4, minmax(90px, 1fr)) minmax(100px, 1fr);
+  gap: 0.5rem;
+  padding: 0.85rem 1rem;
+  background: rgba(255, 255, 255, 0.9);
+}
+
+.tasks-header {
+  background: rgba(186, 33, 46, 0.1);
+  font-weight: 600;
+  color: #5c131a;
+}
+
+.add-task-form {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(140px, 1fr));
+  gap: 1.25rem;
+  align-items: end;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.field label,
+.order-date-field label {
+  font-weight: 600;
+  color: #5c131a;
+}
+
+.field input,
+.order-date-field input {
+  border-radius: 12px;
+  border: 1px solid rgba(122, 20, 32, 0.25);
+  padding: 0.6rem 0.85rem;
+  font-size: 0.95rem;
+  background: #fff;
+  color: #44282b;
+}
+
+.order-dates {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  grid-column: span 3;
+}
+
+.order-date-field {
+  min-width: 180px;
+  flex: 1 1 200px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.add-task-form .actions {
+  grid-column: span 3;
+  display: flex;
+  justify-content: flex-end;
+}
+
+@media (max-width: 1024px) {
+  .operator-dashboard {
+    grid-template-columns: minmax(200px, 240px) minmax(0, 1fr);
+    gap: 1.75rem;
+  }
+
+  .add-task-form {
+    grid-template-columns: repeat(2, minmax(140px, 1fr));
+  }
+
+  .order-dates,
+  .add-task-form .actions {
+    grid-column: span 2;
+  }
+}
+
+@media (max-width: 768px) {
+  :host {
+    padding: 1rem;
+  }
+
+  .operator-dashboard {
+    grid-template-columns: 1fr;
+  }
+
+  .operator-menu {
+    flex-direction: column;
+  }
+
+  .content-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .session-actions {
+    align-items: flex-start;
+  }
+
+  .tasks-row {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .add-task-form {
+    grid-template-columns: 1fr;
+  }
+
+  .order-dates,
+  .add-task-form .actions {
+    grid-column: span 1;
+  }
+}

--- a/frontend/src/app/components/operator-dashboard/operator-dashboard.component.html
+++ b/frontend/src/app/components/operator-dashboard/operator-dashboard.component.html
@@ -1,0 +1,178 @@
+<div class="operator-dashboard">
+  <aside class="operator-menu">
+    <h2>Menú del operador</h2>
+    <p>Seleccione una sección para trabajar.</p>
+    <nav>
+      <button
+        type="button"
+        class="menu-button"
+        [class.active]="activeTab === 'ordenes-activas'"
+        (click)="setActive('ordenes-activas')"
+      >
+        Órdenes activas
+      </button>
+      <button
+        type="button"
+        class="menu-button"
+        [class.active]="activeTab === 'nueva-orden'"
+        (click)="setActive('nueva-orden')"
+      >
+        Crear nueva
+      </button>
+      <button
+        type="button"
+        class="menu-button"
+        [class.active]="activeTab === 'consultar-ordenes'"
+        (click)="setActive('consultar-ordenes')"
+      >
+        Consultar órdenes
+      </button>
+      <button
+        type="button"
+        class="menu-button"
+        [class.active]="activeTab === 'detalle-orden'"
+        (click)="setActive('detalle-orden')"
+      >
+        Detalle de orden
+      </button>
+      <button
+        type="button"
+        class="menu-button"
+        [class.active]="activeTab === 'editar-orden'"
+        (click)="setActive('editar-orden')"
+      >
+        Editar orden
+      </button>
+    </nav>
+  </aside>
+
+  <section class="operator-content">
+    <header class="content-header">
+      <div>
+        <h1>Gestión de órdenes</h1>
+        <p>Crea, consulta y actualiza órdenes de trabajo de forma ágil.</p>
+      </div>
+      <div class="session-actions">
+        <span>Rol: Operador</span>
+        <button type="button" class="secondary">Cerrar sesión</button>
+      </div>
+    </header>
+
+    <article class="orders-card">
+      <header>
+        <div>
+          <h2>Órdenes en curso</h2>
+          <p>Listado automático de órdenes que aún no están finalizadas.</p>
+        </div>
+        <div class="status-selector">
+          <label for="estadoOrden">Estado de la orden</label>
+          <select id="estadoOrden">
+            <option>Abierta</option>
+            <option>En progreso</option>
+            <option>Cerrada</option>
+          </select>
+          <button type="button" class="secondary">Actualizar estado</button>
+        </div>
+      </header>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Número</th>
+            <th>Cliente</th>
+            <th>Vehículo</th>
+            <th>Técnico</th>
+            <th>Inicio</th>
+            <th>Acciones</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>000012</td>
+            <td>Luis Chicaza</td>
+            <td>fasdf</td>
+            <td>Abierta</td>
+            <td>15/07/2024</td>
+            <td class="actions">
+              <button type="button" class="primary">Ver</button>
+              <button type="button" class="secondary">PDF</button>
+            </td>
+          </tr>
+          <tr>
+            <td>000022</td>
+            <td>Luis Chicaza</td>
+            <td>fasdf</td>
+            <td>Elia Camporta</td>
+            <td>15/07/2024</td>
+            <td class="actions">
+              <button type="button" class="primary">Editar</button>
+              <button type="button" class="secondary">PDF</button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </article>
+
+    <article class="order-edit" *ngIf="activeTab === 'editar-orden'">
+      <header>
+        <h2>Tareas de la orden</h2>
+        <button type="button" class="secondary">Actualizar estado</button>
+      </header>
+
+      <div class="tasks-table">
+        <div class="tasks-row tasks-header">
+          <span>Descripción</span>
+          <span>Horas</span>
+          <span>Tarifa</span>
+          <span>Subtotal</span>
+          <span>Inicio</span>
+          <span>Fin</span>
+        </div>
+        <div class="tasks-row">
+          <span>Mantenimiento</span>
+          <span>1.00</span>
+          <span>0.00</span>
+          <span>0.00</span>
+          <span>15/07/2024</span>
+          <span>15/07/2024</span>
+        </div>
+        <div class="tasks-row">
+          <span>Diagnóstico</span>
+          <span>1.00</span>
+          <span>0.00</span>
+          <span>0.00</span>
+          <span>15/07/2024</span>
+          <span>15/07/2024</span>
+        </div>
+      </div>
+
+      <form class="add-task-form">
+        <div class="field">
+          <label for="descripcion">Descripción</label>
+          <input id="descripcion" type="text" placeholder="Ej. Diagnóstico del motor" />
+        </div>
+        <div class="field">
+          <label for="horas">Horas</label>
+          <input id="horas" type="number" min="0" step="0.25" />
+        </div>
+        <div class="field">
+          <label for="tarifa">Tarifa por hora</label>
+          <input id="tarifa" type="number" min="0" step="0.25" />
+        </div>
+        <div class="order-dates">
+          <div class="order-date-field">
+            <label for="inicio">Inicio</label>
+            <input id="inicio" type="date" />
+          </div>
+          <div class="order-date-field">
+            <label for="fin">Fin</label>
+            <input id="fin" type="date" />
+          </div>
+        </div>
+        <div class="actions">
+          <button type="submit" class="primary">Agregar tarea</button>
+        </div>
+      </form>
+    </article>
+  </section>
+</div>

--- a/frontend/src/app/components/operator-dashboard/operator-dashboard.component.ts
+++ b/frontend/src/app/components/operator-dashboard/operator-dashboard.component.ts
@@ -1,0 +1,14 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-operator-dashboard',
+  templateUrl: './operator-dashboard.component.html',
+  styleUrls: ['./operator-dashboard.component.css']
+})
+export class OperatorDashboardComponent {
+  activeTab = 'ordenes-activas';
+
+  setActive(tab: string) {
+    this.activeTab = tab;
+  }
+}

--- a/frontend/src/app/pages/login.component.ts
+++ b/frontend/src/app/pages/login.component.ts
@@ -1,13 +1,9 @@
 import { Component } from '@angular/core';
 import { Router } from '@angular/router';
-import { FormsModule } from '@angular/forms';
-import { CommonModule } from '@angular/common';
 import { AuthService } from '../services/auth.service';
 
 @Component({
   selector: 'app-login',
-  standalone: true,
-  imports: [CommonModule, FormsModule],
   template: `
     <h2>Login</h2>
 


### PR DESCRIPTION
## Summary
- crea un panel de operador con barra lateral alineada y formularios responsivos para fechas
- expone una ruta protegida y un acceso rápido desde el encabezado para el panel de operador
- ajusta el componente de login para integrarlo correctamente con el módulo principal

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de25256a0c8324a79ae24b8d615c97